### PR TITLE
Feat: Modificando CI para validar builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 
 REPORT = manual.pdf
-LATEX = pdflatex -interaction nonstopmode --shell-escape -output-directory _build
+LATEX = pdflatex -interaction nonstopmode -halt-on-error --shell-escape -output-directory _build
 DEPS = ./manual.tex
 
 all: $(REPORT)

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,12 @@
 !#/bin/bash
+
 make
 
-exit 0
+if [ -e _build/manual.pdf ]
+then
+  echo "Build success"
+  exit 0
+else
+  echo "Build failed"
+  exit 1
+fi


### PR DESCRIPTION
Hoje o CI não esta validando caso o build não esteja ocorrendo. Com essas modificações o CI irá checar se de fato o arquivo .pdf está sendo gerado ao menos.